### PR TITLE
add initial setup for harvesting

### DIFF
--- a/.env
+++ b/.env
@@ -65,7 +65,9 @@ CKAN__DATAPUSHER__CALLBACK_URL_BASE=http://ckan:5000
 ## Make sure envvars is always last
 ## Note that CKAN__PLUGINS is loaded at initialization of CKAN when using the ckan-docker-base image, before the plugins (and envvar) are loaded
 ## All other variables are only loaded once envvars plugin is loaded.
-CKAN__PLUGINS="image_view text_view datatables_view datastore activity ytp_request hidegroups mailchimp benap pages scheming_datasets scheming_organizations fluent dcat dcat_be_napits clamav envvars"
+## TODO: ckan_harvester is added for testing out the harvester, but should be removed once the dcat_harvester can be used for testing instead
+CKAN__PLUGINS="image_view text_view datatables_view datastore activity ytp_request hidegroups mailchimp benap pages scheming_datasets scheming_organizations fluent dcat dcat_be_napits harvest ckan_harvester dcat_rdf_harvester clamav envvars"
+
 CKAN__HARVEST__MQ__TYPE=redis
 CKAN__HARVEST__MQ__HOSTNAME=redis
 CKAN__HARVEST__MQ__PORT=6379

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -38,6 +38,10 @@ RUN  pip3 install -e git+https://github.com/belgium-its-steering-committee/ckane
 RUN pip3 install -e git+https://github.com/DataShades/ckanext-clamav.git@v1.1.1#egg=ckanext-clamav && \
     pip3 install -r ${APP_DIR}/src/ckanext-clamav/requirements.txt
 
+### Harvest ###
+RUN  pip3 install -e git+https://github.com/ckan/ckanext-harvest.git@v1.6.2#egg=ckanext-harvest && \
+     pip3 install -r ${APP_DIR}/src/ckanext-harvest/pip-requirements.txt
+
 # Copy custom initialization scripts
 COPY --chown=ckan-sys:ckan-sys docker-entrypoint.d/* /docker-entrypoint.d/
 

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -46,6 +46,10 @@ RUN  pip3 install -e git+https://github.com/belgium-its-steering-committee/ckane
 ### custom DCAT (including MobilityDCAT) ###
 RUN  pip3 install -e git+https://github.com/belgium-its-steering-committee/ckanext-dcat-be-napits.git@1.0.0#egg=ckanext-dcat-be-napits
 
+### Harvest ###
+RUN  pip3 install -e git+https://github.com/ckan/ckanext-harvest.git@v1.6.2#egg=ckanext-harvest && \
+     pip3 install -r ${APP_DIR}/src/ckanext-harvest/pip-requirements.txt
+
 ### ClamAV ###
 RUN pip3 install -e git+https://github.com/DataShades/ckanext-clamav.git@v1.1.1#egg=ckanext-clamav && \
     pip3 install -r ${APP_DIR}/src/ckanext-clamav/requirements.txt

--- a/ckan/docker-entrypoint.d/02_setup_harvest.sh
+++ b/ckan/docker-entrypoint.d/02_setup_harvest.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Setup script for ckanext-harvest
+# This script initializes the harvest database tables and sets up supervisor configurations
+
+if [[ $CKAN__PLUGINS == *"harvest"* ]]; then
+   echo "Setting up ckanext-harvest..."
+   
+   # Initialize harvest database tables
+   echo "Initializing harvest database tables..."
+   ckan -c $CKAN_INI db upgrade -p harvest
+else
+   echo "Not configuring Harvest"
+fi
+

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,3 +1,26 @@
+x-ckan-base: &ckan-base
+  build:
+    context: ckan/
+    dockerfile: Dockerfile.dev
+    args:
+      - TZ=${TZ}
+  env_file:
+    - .env
+    - .env.secrets
+  links:
+    - db
+    - solr
+    - redis
+  volumes:
+    - ckan_storage:/var/lib/ckan
+    - ./src:/srv/app/src_extensions
+    - pip_cache:/root/.cache/pip
+    - site_packages:/usr/local/lib/python3.10/site-packages
+    - local_bin:/usr/local/bin
+    # home_dir overrides all extensions installed through dockerfile
+    # see https://github.com/ckan/ckan-docker/issues/225
+    # - home_dir:/srv/app/
+
 volumes:
   ckan_storage:
   pg_data:
@@ -8,37 +31,31 @@ volumes:
   home_dir:
 
 services:
-
   ckan-dev:
-    build:
-      context: ckan/
-      dockerfile: Dockerfile.dev
-      args:
-        - TZ=${TZ}
-    env_file:
-      - .env
-      - .env.secrets
-    links:
-      - db
-      - solr
-      - redis
+    <<: *ckan-base
     ports:
       - "0.0.0.0:${CKAN_PORT_HOST}:5000"
-    volumes:
-      - ckan_storage:/var/lib/ckan
-      - ./src:/srv/app/src_extensions
-      - pip_cache:/root/.cache/pip
-      - site_packages:/usr/local/lib/python3.10/site-packages
-      - local_bin:/usr/local/bin
-      # home_dir overrides all extensions installed through dockerfile
-      # see https://github.com/ckan/ckan-docker/issues/225
-      # - home_dir:/srv/app/
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:5000"]
       interval: 60s
       timeout: 10s
       retries: 3
+
+  ckan-harvest-gather:
+    <<: *ckan-base
+    command: bash -c "ckan --config=/srv/app/ckan.ini harvester gather-consumer"
+    restart: unless-stopped
+    healthcheck:
+      disable: true
+
+
+  ckan-harvest-fetch:
+    <<: *ckan-base
+    command: bash -c "ckan --config=/srv/app/ckan.ini harvester fetch-consumer"
+    restart: unless-stopped
+    healthcheck:
+      disable: true
 
   clamav:
     image: clamav/clamav:stable

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,28 @@
+x-ckan-base: &ckan-base
+  build:
+    context: ckan/
+    dockerfile: Dockerfile
+    args:
+      - TZ=${TZ}
+  networks:
+    - ckannet
+    - dbnet
+    - solrnet
+    - redisnet
+  env_file:
+    - .env
+    - .env.secrets
+  depends_on:
+    db:
+      condition: service_healthy
+    solr:
+      condition: service_healthy
+    redis:
+      condition: service_healthy
+  volumes:
+    - ckan_storage:/var/lib/ckan
+    - pip_cache:/root/.cache/pip
+    - site_packages:/usr/lib/python3.10/site-packages
 volumes:
   ckan_storage:
   pg_data:
@@ -5,45 +30,28 @@ volumes:
   pip_cache:
   site_packages:
 
-services:    
+services:
   ckan:
-    build:
-      context: ckan/
-      dockerfile: Dockerfile
-      args:
-        - TZ=${TZ}
-    networks:
-      - ckannet
-      - dbnet
-      - solrnet
-      - redisnet
-    env_file:
-      - .env
-      - .env.secrets
-    depends_on:
-      db:
-        condition: service_healthy
-      solr:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    volumes:
-      - ckan_storage:/var/lib/ckan
-      - pip_cache:/root/.cache/pip
-      - site_packages:/usr/lib/python3.10/site-packages
+    <<: *ckan-base
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:5000/api/action/status_show"]
       interval: 60s
       timeout: 10s
       retries: 3
+  ckan-harvest-gather:
+    <<: *ckan-base
+    command: bash -c "ckan --config=/srv/app/ckan.ini harvester gather-consumer"
+    healthcheck:
+      disable: true
 
-  clamav:
-    image: clamav/clamav:stable
-    networks:
-      - ckannet
-    restart: unless-stopped
-    
+
+  ckan-harvest-fetch:
+    <<: *ckan-base
+    command: bash -c "ckan --config=/srv/app/ckan.ini harvester fetch-consumer"
+    healthcheck:
+      disable: true
+
   datapusher:
     networks:
       - ckannet


### PR DESCRIPTION
Adds ckanext-harvest and two services to run the commands continously that ckanext-harvest expects.

Note that the docs mention to use supervisor, but this is not needed (and was removed in CKAN 2.11) for the docker setup.

This might not be the best way to approach this: definitely adjust if needed. For now it seems to work as expected.

This also adds ckan-harvester plugin, which can be used to check if the pipeline works as intended. This plugin can be removed from the list once the dcat-harvesting works.